### PR TITLE
use correct ENV VARs

### DIFF
--- a/model/src/main/java/io/streamzi/openshift/dataflow/model/ProcessorConstants.java
+++ b/model/src/main/java/io/streamzi/openshift/dataflow/model/ProcessorConstants.java
@@ -5,6 +5,6 @@ package io.streamzi.openshift.dataflow.model;
  * @author hhiden
  */
 public class ProcessorConstants {
-    public static final String KAFKA_BOOTSTRAP_SERVERS = "STREAMZI_KAFKA_BOOTSTRAP_SERVER";
+    public static final String KAFKA_BOOTSTRAP_SERVERS = "BOOTSTRAP_SERVERS";
     public static final String NODE_UUID = "STREAMZI_NODE_UUID";
 }

--- a/operations/nodejs/filter-events/main.js
+++ b/operations/nodejs/filter-events/main.js
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-var kafkaHost = process.env.STREAMZI_KAFKA_BOOTSTRAP_SERVER;
+var kafkaHost = process.env.BOOTSTRAP_SERVERS;
 var nodeUuid = process.env.STREAMZI_NODE_UUID;
 var sourceTopic = process.env.INPUT_DATA;
 var targetTopic = process.env.OUTPUT_DATA;


### PR DESCRIPTION
Not sure why `STREAMZI_KAFKA_BOOTSTRAP_SERVER` was introduced.

but those values were never set.  Instead we can just leverage the normal `BOOTSTRAP_SERVERS` var