### PR TITLE
Multiple copies of a node in a flow

### DIFF
--- a/container/src/main/java/io/streamzi/openshift/dataflow/container/kafka/KafkaCloudEventInputImpl.java
+++ b/container/src/main/java/io/streamzi/openshift/dataflow/container/kafka/KafkaCloudEventInputImpl.java
@@ -102,8 +102,7 @@ public class KafkaCloudEventInputImpl extends CloudEventInput implements Runnabl
 
             Properties properties = new Properties();
             properties.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-            properties.put(ConsumerConfig.GROUP_ID_CONFIG, "processor-group");
-            properties.put(ConsumerConfig.CLIENT_ID_CONFIG, processorUuid);
+            properties.put(ConsumerConfig.GROUP_ID_CONFIG, processorUuid);
             properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
             properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
             properties.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 1000);

--- a/watcher/src/main/java/io/streamzi/openshift/DeploymentConfigBuilder.java
+++ b/watcher/src/main/java/io/streamzi/openshift/DeploymentConfigBuilder.java
@@ -49,7 +49,7 @@ public class DeploymentConfigBuilder {
 
             if(node.getProcessorType()==ProcessorConstants.ProcessorType.DEPLOYABLE_IMAGE){
                 // Only create deployments for deployable image nodes
-                final String dcName = flow.getName() + "-" + node.getImageName(); //TODO: Add back in to get unique deployments + "-" + x;
+                final String dcName = flow.getName() + "-" + node.getImageName() + "-" + node.getUuid().substring(0,6);
                 final Container container = populateNodeDeployments(node);
 
                 final DeploymentConfig dc = new io.fabric8.openshift.api.model.DeploymentConfigBuilder()


### PR DESCRIPTION
Added generation of unique name for multiple nodes of the same type within a flow. Fixed usage of Kafka consumerGroupId in client - multiple nodes of same type will have different consumerGroupIds but replicas of the same container will share a consumerGroupId.

@matzew This may conflict with your handling of dockerhub images...