### PR TITLE
Cloud CRD

### DIFF
--- a/manager/src/main/java/io/streamzi/openshift/API.java
+++ b/manager/src/main/java/io/streamzi/openshift/API.java
@@ -34,10 +34,10 @@ public class API {
 
     private final ObjectMapper MAPPER = new ObjectMapper();
 
-
     @EJB(beanInterface = ClientContainer.class)
     private ClientContainer container;
 
+    /* Global settings that each block gets */
     private final String bootstrapServersDefault = "my-cluster-kafka:9092";
     private final String brokerUrlDefault = "amqp://dispatch.myproject.svc:5672";
 
@@ -70,7 +70,6 @@ public class API {
                 DoneableFlow.class)
                 .inNamespace(container.getOSClient().getNamespace())
                 .withName(name).get());
-
     }
 
     @GET
@@ -207,4 +206,46 @@ public class API {
         }
         return results;
     }
+
+    @GET
+    @Path("/clouds")
+    @Produces("application/json")
+    public String getClouds() throws Exception {
+
+        final CustomResourceDefinition cloudCRD = container.getOSClient().customResourceDefinitions().withName("clouds.streamzi.io").get();
+        if (cloudCRD == null) {
+            logger.severe("Can't find Cloud CRD");
+            return "[]";
+        }
+
+        return MAPPER.writeValueAsString(new ArrayList<>(container.getOSClient().customResources(
+                cloudCRD,
+                Cloud.class,
+                CloudList.class,
+                DoneableCloud.class)
+                .inNamespace(container.getOSClient().getNamespace())
+                .list().getItems()));
+    }
+
+    @GET
+    @Path("/clouds/{name}")
+    @Produces("application/json")
+    public String getCloud(@PathParam("name") String name) throws Exception {
+
+        final CustomResourceDefinition cloudCRD = container.getOSClient().customResourceDefinitions().withName("clouds.streamzi.io").get();
+        if (cloudCRD == null) {
+            logger.severe("Can't find Cloud CRD");
+            return "";
+        }
+
+        return MAPPER.writeValueAsString(container.getOSClient().customResources(
+                cloudCRD,
+                Cloud.class,
+                CloudList.class,
+                DoneableCloud.class)
+                .inNamespace(container.getOSClient().getNamespace())
+                .withName(name)
+                .get());
+    }
+
 }

--- a/manager/src/main/java/io/streamzi/openshift/ClientContainer.java
+++ b/manager/src/main/java/io/streamzi/openshift/ClientContainer.java
@@ -4,6 +4,7 @@ package io.streamzi.openshift;
 import io.fabric8.openshift.client.OpenShiftClient;
 
 import javax.ejb.Local;
+import java.util.Set;
 
 /**
  * Methods for accessing the openshift client, looking up storage dirs etc.
@@ -12,6 +13,11 @@ import javax.ejb.Local;
  */
 @Local
 public interface ClientContainer {
-    public String getNamespace();
-    public OpenShiftClient getOSClient();
+    String getNamespace();
+
+    OpenShiftClient getOSClient();
+
+    Set<String> getOSClientNames();
+
+    OpenShiftClient getOsClient(String name);
 }

--- a/manager/src/main/java/io/streamzi/openshift/ClientContainerBean.java
+++ b/manager/src/main/java/io/streamzi/openshift/ClientContainerBean.java
@@ -1,11 +1,19 @@
 package io.streamzi.openshift;
 
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
+import io.streamzi.openshift.dataflow.model.crds.Cloud;
+import io.streamzi.openshift.dataflow.model.crds.CloudList;
+import io.streamzi.openshift.dataflow.model.crds.DoneableCloud;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.ejb.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 
@@ -18,16 +26,47 @@ import java.util.logging.Logger;
 public class ClientContainerBean implements ClientContainer {
 
     private static final Logger logger = Logger.getLogger(ClientContainerBean.class.getName());
-    private OpenShiftClient osClient;
+    private final Map<String, OpenShiftClient> apiClients = new HashMap<>();
 
     @PostConstruct
     public void init() {
 
         logger.info("Starting ClientContainer");
 
-        osClient = new DefaultOpenShiftClient();
-        logger.info("URL:" + osClient.getOpenshiftUrl().toString());
-        logger.info("Namespace: " + osClient.getNamespace());
+        //Get the local OpenShift Client
+        OpenShiftClient osClient = new DefaultOpenShiftClient();
+        logger.info("Local OpenShift URL: " + osClient.getOpenshiftUrl().toString());
+        logger.info("Local OpenShift Namespace: " + osClient.getNamespace());
+        apiClients.put("local", osClient);
+
+        //Get any other OpenShift Clients
+        final CustomResourceDefinition cloudCRD = osClient.customResourceDefinitions().withName("clouds.streamzi.io").get();
+        if (cloudCRD == null) {
+            logger.info("Can't find Cloud CRDs - Local OpenShift only");
+            return;
+        }
+
+        osClient.customResources(
+                cloudCRD,
+                Cloud.class,
+                CloudList.class,
+                DoneableCloud.class)
+                .inNamespace(osClient.getNamespace())
+                .list()
+                .getItems()
+                .stream()
+                .filter(cloud -> !cloud.getMetadata().getName().equals("local"))
+                .forEach(cloud -> {
+                    ConfigBuilder configBuilder = new ConfigBuilder();
+                    configBuilder.withMasterUrl("https://" + cloud.getSpec().getHostname() + ":" + cloud.getSpec().getPort());
+                    configBuilder.withOauthToken(cloud.getSpec().getToken());
+
+                    OpenShiftClient client = new DefaultOpenShiftClient(configBuilder.build());
+                    apiClients.put(cloud.getMetadata().getName(), client);
+
+                    logger.info("Remote OpenShift URL (" + cloud.getMetadata().getName() + ": " + client.getOpenshiftUrl().toString());
+                    logger.info("Remote OpenShift Namespace(" + cloud.getMetadata().getName() + ": " + client.getNamespace());
+                });
     }
 
     @PreDestroy
@@ -42,6 +81,16 @@ public class ClientContainerBean implements ClientContainer {
 
     @Override
     public OpenShiftClient getOSClient() {
-        return osClient;
+        return apiClients.get("local");
+    }
+
+    @Override
+    public Set<String> getOSClientNames() {
+        return apiClients.keySet();
+    }
+
+    @Override
+    public OpenShiftClient getOsClient(String name) {
+        return apiClients.get(name);
     }
 }

--- a/manager/src/main/resources/cloud-crd.yml
+++ b/manager/src/main/resources/cloud-crd.yml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clouds.streamzi.io
+spec:
+  group: streamzi.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: clouds
+    singular: cloud
+    kind: Cloud
+    shortNames:
+    - cloud

--- a/model/src/main/java/io/streamzi/openshift/dataflow/model/crds/Cloud.java
+++ b/model/src/main/java/io/streamzi/openshift/dataflow/model/crds/Cloud.java
@@ -1,0 +1,25 @@
+package io.streamzi.openshift.dataflow.model.crds;
+
+import io.fabric8.kubernetes.client.CustomResource;
+
+public class Cloud extends CustomResource {
+
+    private CloudSpec spec;
+
+    @Override
+    public String toString() {
+        return "Processor{" +
+                "apiVersion='" + getApiVersion() + '\'' +
+                ", metadata=" + getMetadata() +
+                ", spec=" + spec +
+                '}';
+    }
+
+    public CloudSpec getSpec() {
+        return spec;
+    }
+
+    public void setSpec(CloudSpec spec) {
+        this.spec = spec;
+    }
+}

--- a/model/src/main/java/io/streamzi/openshift/dataflow/model/crds/CloudList.java
+++ b/model/src/main/java/io/streamzi/openshift/dataflow/model/crds/CloudList.java
@@ -1,0 +1,6 @@
+package io.streamzi.openshift.dataflow.model.crds;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+public class CloudList extends CustomResourceList<Cloud> {
+}

--- a/model/src/main/java/io/streamzi/openshift/dataflow/model/crds/CloudSpec.java
+++ b/model/src/main/java/io/streamzi/openshift/dataflow/model/crds/CloudSpec.java
@@ -1,0 +1,62 @@
+package io.streamzi.openshift.dataflow.model.crds;
+
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+@JsonDeserialize(
+        using = JsonDeserializer.None.class
+)
+public class CloudSpec implements KubernetesResource {
+
+    private String description;
+
+    private String hostname;
+
+    private int port;
+
+    //todo: Should this be a secret?
+    private String token;
+
+    @Override
+    public String toString() {
+        return "CloudSpec{" +
+                "description='" + description + '\'' +
+                ", hostname='" + hostname + '\'' +
+                ", port=" + port +
+                ", token='" + token + '\'' +
+                '}';
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/model/src/main/java/io/streamzi/openshift/dataflow/model/crds/DoneableCloud.java
+++ b/model/src/main/java/io/streamzi/openshift/dataflow/model/crds/DoneableCloud.java
@@ -1,0 +1,11 @@
+package io.streamzi.openshift.dataflow.model.crds;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.client.CustomResourceDoneable;
+
+public class DoneableCloud extends CustomResourceDoneable<Cloud> {
+
+    public DoneableCloud(Cloud resource, Function function) {
+        super(resource, function);
+    }
+}


### PR DESCRIPTION
Manager has ability to interact with multiple clouds. 

* CRD for `Cloud`.
* List `Cloud` in API
* added ClientContainerBean#getClient(String name) and retained ClientContainerBean#getClient() for local client
* Doesn't require CRD to be installed for purely local operartion
