### PR TITLE
Using Topic CRD API instead of ConfigMap for Strimzi Topic Operator

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-oc delete dc -l app=${1}
-oc delete cm -l streamzi.io/kind=ev
-oc delete cm -l strimzi.io/kind=topic

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -12,6 +12,12 @@
     
     <dependencies>
         <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>api</artifactId>
+            <version>0.7.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.streamzi</groupId>
             <artifactId>jcloudevents-api</artifactId>
         </dependency>

--- a/model/src/main/java/io/streamzi/openshift/dataflow/deployment/TargetState.java
+++ b/model/src/main/java/io/streamzi/openshift/dataflow/deployment/TargetState.java
@@ -1,13 +1,35 @@
 package io.streamzi.openshift.dataflow.deployment;
 
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.streamzi.openshift.dataflow.FlowUtil;
-import io.streamzi.openshift.dataflow.model.*;
 
-import java.util.*;
+import io.streamzi.openshift.dataflow.model.ProcessorConstants;
+import io.streamzi.openshift.dataflow.model.ProcessorFlow;
+import io.streamzi.openshift.dataflow.model.ProcessorInputPort;
+import io.streamzi.openshift.dataflow.model.ProcessorLink;
+import io.streamzi.openshift.dataflow.model.ProcessorNode;
+import io.streamzi.openshift.dataflow.model.ProcessorOutputPort;
+import io.strimzi.api.kafka.model.KafkaTopic;
+import io.strimzi.api.kafka.model.KafkaTopicBuilder;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyMap;
 
 public class TargetState {
 
@@ -21,7 +43,7 @@ public class TargetState {
 
     private Set<DeploymentConfig> deploymentConfigs = new HashSet<>();
 
-    private Set<ConfigMap> topicConfigMaps = new HashSet<>();
+    private Set<CustomResource> topicCrds = new HashSet<>();
 
     private Set<ConfigMap> evConfigMaps = new HashSet<>();
 
@@ -47,12 +69,12 @@ public class TargetState {
         this.deploymentConfigs = deploymentConfigs;
     }
 
-    public Set<ConfigMap> getTopicConfigMaps() {
-        return topicConfigMaps;
+    public Set<CustomResource> getTopicCrds() {
+        return topicCrds;
     }
 
-    public void setTopicConfigMaps(Set<ConfigMap> topicConfigMaps) {
-        this.topicConfigMaps = topicConfigMaps;
+    public void setTopicCrds(Set<CustomResource> topicCrds) {
+        this.topicCrds = topicCrds;
     }
 
     public Set<ConfigMap> getEvConfigMaps() {
@@ -67,8 +89,8 @@ public class TargetState {
         return deploymentConfigs.add(deploymentConfig);
     }
 
-    public boolean add(ConfigMap configMap) {
-        return topicConfigMaps.add(configMap);
+    public boolean add(CustomResource customResource) {
+        return topicCrds.add(customResource);
     }
 
     public Set<String> getDeploymentConfigNames() {
@@ -80,7 +102,7 @@ public class TargetState {
 
     public Set<String> getConfigMapNames() {
         Set<String> topics =
-                topicConfigMaps.stream()
+                topicCrds.stream()
                         .map(cm -> cm.getMetadata().getName())
                         .collect(Collectors.toSet());
 
@@ -109,10 +131,10 @@ public class TargetState {
                         .collect(Collectors.toSet()));
 
 
-        topicConfigMaps.addAll(flow.getLinks().stream()
+        topicCrds.addAll(flow.getLinks().stream()
                 .filter(link -> link.getSource().getParent().getProcessorType().equals(ProcessorConstants.ProcessorType.DEPLOYABLE_IMAGE))
                 .filter(link -> calculateTopicHost(link.getSource().getParent()).equals(cloudName))
-                .map(this::buildTopicConfigMaps)
+                .map(this::buildTopicCustomResource)
                 .collect(Collectors.toSet()));
 
     }
@@ -232,30 +254,28 @@ public class TargetState {
 
     }
 
-    private ConfigMap buildTopicConfigMaps(ProcessorLink link) {
-
-        String topicName = flow.getName() + "-" + link.getSource().getParent().getUuid() + "-" + link.getSource().getName();
-
-        final Map<String, String> data = new HashMap<>();
-        data.put("name", topicName);
-        data.put("partitions", "20");
-        data.put("replicas", "1");
+    private CustomResource buildTopicCustomResource(final ProcessorLink link) {
+        logger.info("Building Topic CRD ");
+        final String topicName = flow.getName() + "-" + link.getSource().getParent().getUuid() + "-" + link.getSource().getName();
 
         final Map<String, String> labels = new HashMap<>();
         labels.put("strimzi.io/cluster", "my-cluster");
-        labels.put("strimzi.io/kind", "topic");
-        labels.put("streamzi.io/source", "autocreated");
         labels.put("app", flow.getName());
 
-        return new ConfigMapBuilder()
-                .withNewMetadata()
-                .withName(topicName)
-                .withLabels(labels)
-                .endMetadata()
-                .withData(data)
-                .build();
-    }
+        // annotate that our framework was creating this topic!
+        labels.put("streamzi.io/source", "autocreated");
 
+        final KafkaTopic topic = new KafkaTopicBuilder()
+                .withMetadata(new ObjectMetaBuilder().withName(topicName).withLabels(labels).build())
+                .withNewSpec()
+                    .withReplicas(1)
+                    .withPartitions(20)
+                    .withConfig(emptyMap())
+                .endSpec()
+                .build();
+
+        return topic;
+    }
 
     private String calculateTopicHost(ProcessorNode node) {
         if (node.getOutputCloud() != null && !node.getOutputCloud().isEmpty()) {
@@ -264,7 +284,6 @@ public class TargetState {
 
         Optional<String> optCloud = node.getTargetClouds().keySet().stream().max(Comparator.comparingInt(key -> node.getTargetClouds().get(key)));
         return optCloud.orElse("UNKNONW");
-
     }
 
 }

--- a/model/src/test/java/io/streamzi/openshift/dataflow/tests/DeploymentTest.java
+++ b/model/src/test/java/io/streamzi/openshift/dataflow/tests/DeploymentTest.java
@@ -42,8 +42,8 @@ public class DeploymentTest {
     public void testConversionToDC() throws Exception {
 
         Map<String, String> bootstrapServerCache = new HashMap<>();
-        bootstrapServerCache.put("local", "my-cluster-kafka:9092");
-        bootstrapServerCache.put("azure", "my-cluster-kafka:9092");
+        bootstrapServerCache.put("local", "my-cluster-kafka-bootstrap:9092");
+        bootstrapServerCache.put("azure", "my-cluster-kafka-bootstrap:9092");
 
         InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream("deployment-cr.json");
 
@@ -68,8 +68,8 @@ public class DeploymentTest {
     public void testStickyCloud() throws Exception {
 
         Map<String, String> bootstrapServerCache = new HashMap<>();
-        bootstrapServerCache.put("local", "my-cluster-kafka:9092");
-        bootstrapServerCache.put("azure", "my-cluster-kafka:9092");
+        bootstrapServerCache.put("local", "my-cluster-kafka-bootstrap:9092");
+        bootstrapServerCache.put("azure", "my-cluster-kafka-bootstrap:9092");
 
         InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream("sticky-cr.json");
 
@@ -80,12 +80,12 @@ public class DeploymentTest {
         localTarget.build();
 
         assertThat(localTarget.getDeploymentConfigs().size()).isEqualTo(2);
-        assertThat(localTarget.getTopicConfigMaps().size()).isEqualTo(1);
+        assertThat(localTarget.getTopicCrds().size()).isEqualTo(1);
 
         TargetState azureTarget = new TargetState("azure", flow, bootstrapServerCache);
         azureTarget.build();
 
-        assertThat(azureTarget.getTopicConfigMaps().size()).isEqualTo(0);
+        assertThat(azureTarget.getTopicCrds().size()).isEqualTo(0);
 
         System.out.println("Done");
 

--- a/model/src/test/resources/deployment-cr.json
+++ b/model/src/test/resources/deployment-cr.json
@@ -68,7 +68,7 @@
   ],
   "settings": {},
   "globalSettings": {
-    "STREAMZI_KAFKA_BOOTSTRAP_SERVER": "my-cluster-kafka:9092",
+    "STREAMZI_KAFKA_BOOTSTRAP_SERVER": "my-cluster-kafka-bootstrap:9092",
     "broker.url": "amqp://dispatch.myproject.svc:5672"
   },
   "name": "partition-flow"

--- a/model/src/test/resources/flow-cr.json
+++ b/model/src/test/resources/flow-cr.json
@@ -37,7 +37,7 @@
   ],
   "settings": {},
   "globalSettings": {
-    "STREAMZI_KAFKA_BOOTSTRAP_SERVER": "my-cluster-kafka:9092",
+    "STREAMZI_KAFKA_BOOTSTRAP_SERVER": "my-cluster-kafka-bootstrap:9092",
     "broker.url": "amqp://dispatch.myproject.svc:5672"
   },
   "name": "flow17"

--- a/model/src/test/resources/sticky-cr.json
+++ b/model/src/test/resources/sticky-cr.json
@@ -47,7 +47,7 @@
   ],
   "settings": {},
   "globalSettings": {
-    "STREAMZI_KAFKA_BOOTSTRAP_SERVER": "my-cluster-kafka:9092",
+    "STREAMZI_KAFKA_BOOTSTRAP_SERVER": "my-cluster-kafka-bootstrap:9092",
     "broker.url": "amqp://dispatch.myproject.svc:5672"
   },
   "name": "f"

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
             <name>JBoss Thirdparty Releases</name>
             <url>https://repository.jboss.org/nexus/service/local/repositories/thirdparty-releases/content/</url>
         </repository>
+        <repository>
+            <id>jboss-thirdparty-uploads</id>
+            <name>JBoss Thirdparty Uploads</name>
+            <url>https://repository.jboss.org/nexus/service/local/repositories/thirdparty-uploads/content/</url>
+        </repository>
     </repositories>
 
 </project>

--- a/watcher/src/main/java/io/streamzi/openshift/FlowController.java
+++ b/watcher/src/main/java/io/streamzi/openshift/FlowController.java
@@ -9,6 +9,10 @@ import io.streamzi.openshift.dataflow.crds.Flow;
 import io.streamzi.openshift.dataflow.crds.FlowList;
 import io.streamzi.openshift.dataflow.deployment.TargetState;
 import io.streamzi.openshift.dataflow.model.ProcessorFlow;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.KafkaTopicList;
+import io.strimzi.api.kafka.model.DoneableKafkaTopic;
+import io.strimzi.api.kafka.model.KafkaTopic;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -48,11 +52,11 @@ public class FlowController {
                     target.build();
 
                     //create / update Strimzi Topic configmaps
-                    target.getTopicConfigMaps()
-                            .forEach(cm -> client.configMaps()
+                    target.getTopicCrds()
+                            .forEach(cr -> client.customResources(Crds.topic(), KafkaTopic.class, KafkaTopicList.class, DoneableKafkaTopic.class)
                                     .inNamespace(client.getNamespace())
-                                    .withName(cm.getMetadata().getName())
-                                    .createOrReplace(cm));
+                                    .withName(cr.getMetadata().getName())
+                                    .createOrReplace((KafkaTopic) cr));
 
                     //create / update deployments
                     target.getDeploymentConfigs().forEach(dc -> client.deploymentConfigs()


### PR DESCRIPTION
Tested w/ Strimzi 0.7.0 and worked:

* tested manual creation of two topics (`kubectl create -f ./my-cr.yml`), one had the `source` label, one not.

_RESULT_ only the topic w/o our label showed up :heavy_check_mark: 

* created a flow from the archetype, and saw that `kafkatopic` CRD API was used, e.g. in the logs..

Saw (`oc get kafkatopic`) that one was created - here is the yaml:
```
oc get kafkatopic sf1-401c1943-a74d-8adf-a637-c9155d34e881-output-data -o yaml 
```

Output:
```
apiVersion: kafka.strimzi.io/v1alpha1
kind: KafkaTopic
metadata:
  annotations: {}
  clusterName: ""
  creationTimestamp: 2018-09-20T08:23:24Z
  finalizers: []
  generation: 1
  labels:
    app: sf1
    streamzi.io/source: autocreated
    strimzi.io/cluster: my-cluster
  name: sf1-401c1943-a74d-8adf-a637-c9155d34e881-output-data
  namespace: myproject
  ownerReferences: []
  resourceVersion: "149006"
  selfLink: /apis/kafka.strimzi.io/v1alpha1/namespaces/myproject/kafkatopics/sf1-401c1943-a74d-8adf-a637-c9155d34e881-output-data
  uid: 70f252d4-bcae-11e8-a505-c85b765a6fb1
spec:
  config: {}
  partitions: 20
  replicas: 1
``` 